### PR TITLE
fix/ci-job-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
   release:
     name: Release
-    if: ${{ success() && github.base_ref == 'master' }}
+    if: ${{ success() && github.ref_name == 'master' }}
     needs: ["build", "unit_tests"]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Avoid PRs to trigger release condition when is not merging on master